### PR TITLE
Include a web_url method to build finished event

### DIFF
--- a/lib/lita/buildkite_build_finished_event.rb
+++ b/lib/lita/buildkite_build_finished_event.rb
@@ -29,6 +29,10 @@ class BuildkiteBuildFinishedEvent
     @data.fetch("pipeline", {}).fetch("slug", "")
   end
 
+  def build_web_url
+    @data.fetch("build", {}).fetch("web_url", "")
+  end
+
   def passed?
     @data.fetch("build", {}).fetch("state", "") == "passed"
   end

--- a/spec/buildkite_build_finished_event_spec.rb
+++ b/spec/buildkite_build_finished_event_spec.rb
@@ -42,6 +42,12 @@ describe BuildkiteBuildFinishedEvent do
     end
   end
 
+  describe '.build_web_url' do
+    it "returns with the build web_url" do
+      expect(event.build_web_url).to eq "https://buildkite.com/org-name/pipeline-name/builds/2"
+    end
+  end
+
   describe '.passed?' do
     it "returns true" do
       expect(event.passed?).to eq true


### PR DESCRIPTION
This PR adds a method so the web URL can be accessed and utilised.
