### PR TITLE
Store "best records" and report on failure

### DIFF
--- a/lib/lita/build_status_report.rb
+++ b/lib/lita/build_status_report.rb
@@ -1,0 +1,21 @@
+class BuildStatusReport
+  def initialize(event, days_since_last_failure, prev_days_since_last_failure)
+    @event = event
+    @days_since_last_failure = days_since_last_failure
+    @prev_days_since_last_failure = prev_days_since_last_failure
+
+    yield message if message
+  end
+
+  private
+
+  def message
+    @message ||= begin
+      if @days_since_last_failure < @prev_days_since_last_failure
+        "#{@event.pipeline} failed after #{@prev_days_since_last_failure} day(s)"
+      elsif @days_since_last_failure > @prev_days_since_last_failure
+        "#{@event.pipeline} is #{@days_since_last_failure} day(s) without a failure!"
+      end
+    end
+  end
+end

--- a/lib/lita/build_status_report.rb
+++ b/lib/lita/build_status_report.rb
@@ -1,8 +1,9 @@
 class BuildStatusReport
-  def initialize(event, days_since_last_failure, prev_days_since_last_failure)
+  def initialize(event, days_since_last_failure, prev_days_since_last_failure, most_successful_days)
     @event = event
     @days_since_last_failure = days_since_last_failure
     @prev_days_since_last_failure = prev_days_since_last_failure
+    @most_successful_days = most_successful_days
 
     yield message if message
   end
@@ -11,10 +12,18 @@ class BuildStatusReport
 
   def message
     @message ||= begin
-      if @days_since_last_failure < @prev_days_since_last_failure
-        "#{@event.pipeline} failed after #{@prev_days_since_last_failure} day(s)"
-      elsif @days_since_last_failure > @prev_days_since_last_failure
-        "#{@event.pipeline} is #{@days_since_last_failure} day(s) without a failure!"
+      if @days_since_last_failure > @prev_days_since_last_failure
+        if @prev_days_since_last_failure >= @most_successful_days
+          "#{@event.pipeline} broke a new record! #{@days_since_last_failure} days without a failure 🎉"
+        else
+          "#{@event.pipeline} is #{@days_since_last_failure} days without a failure. The current record is #{@most_successful_days}. Aim for the top!"
+        end
+      elsif @days_since_last_failure < @prev_days_since_last_failure
+        if @prev_days_since_last_failure >= @most_successful_days
+          "#{@event.pipeline} ended it's record breaking run of #{@prev_days_since_last_failure} days without a failure 😢"
+        else
+          "#{@event.pipeline} failed after #{@prev_days_since_last_failure} days. The current record is #{@most_successful_days}. Needs improvement!"
+        end
       end
     end
   end

--- a/lib/lita/build_status_report.rb
+++ b/lib/lita/build_status_report.rb
@@ -13,16 +13,12 @@ class BuildStatusReport
   def message
     @message ||= begin
       if @days_since_last_failure > @prev_days_since_last_failure
-        if @prev_days_since_last_failure >= @most_successful_days
-          "#{@event.pipeline} broke a new record! #{@days_since_last_failure} days without a failure 🎉"
-        else
-          "#{@event.pipeline} is #{@days_since_last_failure} days without a failure. The current record is #{@most_successful_days}. Aim for the top!"
-        end
+        "#{@event.pipeline} is #{@days_since_last_failure} days without a failure"
       elsif @days_since_last_failure < @prev_days_since_last_failure
         if @prev_days_since_last_failure >= @most_successful_days
           "#{@event.pipeline} ended it's record breaking run of #{@prev_days_since_last_failure} days without a failure 😢"
         else
-          "#{@event.pipeline} failed after #{@prev_days_since_last_failure} days. The current record is #{@most_successful_days}. Needs improvement!"
+          "#{@event.pipeline} failed after #{@prev_days_since_last_failure} days, previous best was #{@most_successful_days}"
         end
       end
     end

--- a/lib/lita/days_since_master_failure.rb
+++ b/lib/lita/days_since_master_failure.rb
@@ -24,12 +24,8 @@ module Lita
       private
 
       def process_build_finished(event, &block)
-        repository(event).record_result(event.passed?) do |days_since_last_failure, prev_days_since_last_failure|
-          if days_since_last_failure < prev_days_since_last_failure
-            yield "Oh Oh, #{days_since_last_failure} day(s) since the last master failure on #{event.pipeline}"
-          elsif days_since_last_failure > prev_days_since_last_failure
-            yield "Congratulations! #{days_since_last_failure} day(s) since the last master failure on #{event.pipeline}"
-          end
+        repository(event).record_result(event) do |message|
+          yield message
         end
       end
 

--- a/lib/lita/days_since_master_failure_repository.rb
+++ b/lib/lita/days_since_master_failure_repository.rb
@@ -1,3 +1,5 @@
+require 'lita/build_status_report'
+
 # Provides all persistence logic for the DaysSinceMasterFailure handler, insulating
 # the handler from any knowledge of redis
 class DaysSinceMasterFailureRepository
@@ -9,9 +11,13 @@ class DaysSinceMasterFailureRepository
     initialise_last_failure_at_if_not_set
   end
 
-  def record_result(success, &block)
-    touch_last_failure_at if !success
-    yield days_since_last_failure, last_reported_days
+  def record_result(event, &block)
+    touch_last_failure_at if !event.passed?
+
+    BuildStatusReport.new(event, days_since_last_failure, last_reported_days) do |message|
+      yield message
+    end
+
     touch_last_reported_days
   end
 

--- a/lib/lita/days_since_master_failure_repository.rb
+++ b/lib/lita/days_since_master_failure_repository.rb
@@ -7,12 +7,15 @@ class DaysSinceMasterFailureRepository
     @redis = redis
     @last_failure_key = "last-failure-at-#{pipeline_name}"
     @last_reported_days_key = "last-reported-days-#{pipeline_name}"
+    @most_successful_days_key = "most-successful-days-#{pipeline_name}"
 
     initialise_last_failure_at_if_not_set
+    initialise_most_successful_days_if_not_set
   end
 
   def record_result(event, &block)
     touch_last_failure_at if !event.passed?
+    touch_most_successful_days if !event.passed? && new_record?
 
     BuildStatusReport.new(event, days_since_last_failure, last_reported_days) do |message|
       yield message
@@ -22,6 +25,10 @@ class DaysSinceMasterFailureRepository
   end
 
   private
+
+  def new_record?
+    last_reported_days > most_successful_days
+  end
 
   def seconds_to_days(secs)
     secs.to_i / 60 / 60 / 24
@@ -39,6 +46,10 @@ class DaysSinceMasterFailureRepository
     set_last_reported_days(days_since_last_failure)
   end
 
+  def touch_most_successful_days
+    set_most_successful_days(days_since_last_failure)
+  end
+
   def fetch_last_failure_at
     @redis.get(@last_failure_key).to_i
   end
@@ -47,11 +58,23 @@ class DaysSinceMasterFailureRepository
     @redis.set(@last_reported_days_key, days.to_i)
   end
 
+  def set_most_successful_days(days)
+    @redis.set(@most_successful_days_key, days.to_i)
+  end
+
   def last_reported_days
     @redis.get(@last_reported_days_key).to_i
   end
 
+  def most_successful_days
+    @redis.get(@most_successful_days_key).to_i
+  end
+
   def initialise_last_failure_at_if_not_set
     @redis.setnx(@last_failure_key, ::Time.now.to_i)
+  end
+
+  def initialise_most_successful_days_if_not_set
+    @redis.setnx(@most_successful_days_key, days_since_last_failure)
   end
 end

--- a/lib/lita/days_since_master_failure_repository.rb
+++ b/lib/lita/days_since_master_failure_repository.rb
@@ -17,7 +17,7 @@ class DaysSinceMasterFailureRepository
     touch_last_failure_at if !event.passed?
     touch_most_successful_days if !event.passed? && new_record?
 
-    BuildStatusReport.new(event, days_since_last_failure, last_reported_days) do |message|
+    BuildStatusReport.new(event, days_since_last_failure, last_reported_days, most_successful_days) do |message|
       yield message
     end
 
@@ -47,7 +47,7 @@ class DaysSinceMasterFailureRepository
   end
 
   def touch_most_successful_days
-    set_most_successful_days(days_since_last_failure)
+    set_most_successful_days(last_reported_days)
   end
 
   def fetch_last_failure_at

--- a/spec/build_status_report_spec.rb
+++ b/spec/build_status_report_spec.rb
@@ -8,24 +8,58 @@ RSpec.describe BuildStatusReport do
     context "days_since_last_failure and prev_days_since_last_failure are equal" do
       it "yields nothing" do
         expect { |b|
-          BuildStatusReport.new(event, 1, 1, &b)
+          BuildStatusReport.new(event, 1, 1, 0, &b)
         }.not_to yield_control
       end
     end
 
-    context "days_since_last_failure less than prev_days_since_last_failure" do
-      it "yields a happy message" do
-        expect { |b|
-          BuildStatusReport.new(event, 1, 0, &b)
-        }.to yield_with_args("tc is 1 day(s) without a failure!")
+    context "days_since_last_failure greater than prev_days_since_last_failure" do
+      let(:days_since_last_failure) { 2 }
+      let(:prev_days_since_last_failure) { 1 }
+
+      context "prev_days_since_last_failure greater than most_successful_days" do
+        let(:most_successful_days) { 0 }
+
+        it "yields a happy message" do
+          expect { |b|
+            BuildStatusReport.new(event, days_since_last_failure, prev_days_since_last_failure, most_successful_days, &b)
+          }.to yield_with_args("tc broke a new record! 2 days without a failure 🎉")
+        end
+      end
+
+      context "prev_days_since_last_failure less than most_successful_days" do
+        let(:most_successful_days) { 3 }
+
+        it "yields a happy message" do
+          expect { |b|
+            BuildStatusReport.new(event, days_since_last_failure, prev_days_since_last_failure, most_successful_days, &b)
+          }.to yield_with_args("tc is 2 days without a failure. The current record is 3. Aim for the top!")
+        end
       end
     end
 
-    context "days_since_last_failure greater than prev_days_since_last_failure" do
-      it "yields a sad message" do
-        expect { |b|
-          BuildStatusReport.new(event, 0, 1, &b)
-        }.to yield_with_args("tc failed after 1 day(s)")
+    context "days_since_last_failure less than prev_days_since_last_failure" do
+      let(:days_since_last_failure) { 0 }
+      let(:prev_days_since_last_failure) { 2 }
+
+      context "prev_days_since_last_failure greater than most_successful_days" do
+        let(:most_successful_days) { 0 }
+
+        it "yields a sad message" do
+          expect { |b|
+            BuildStatusReport.new(event, days_since_last_failure, prev_days_since_last_failure, most_successful_days, &b)
+          }.to yield_with_args("tc ended it's record breaking run of 2 days without a failure 😢")
+        end
+      end
+
+      context "prev_days_since_last_failure less than most_successful_days" do
+        let(:most_successful_days) { 3 }
+
+        it "yields a sad message" do
+          expect { |b|
+            BuildStatusReport.new(event, days_since_last_failure, prev_days_since_last_failure, most_successful_days, &b)
+          }.to yield_with_args("tc failed after 2 days. The current record is 3. Needs improvement!")
+        end
       end
     end
   end

--- a/spec/build_status_report_spec.rb
+++ b/spec/build_status_report_spec.rb
@@ -1,0 +1,32 @@
+require "lita/build_status_report"
+require "lita/buildkite_job_finished_event"
+
+RSpec.describe BuildStatusReport do
+  let(:event) { instance_double(BuildkiteBuildFinishedEvent, pipeline: "tc") }
+
+  describe ".new" do
+    context "days_since_last_failure and prev_days_since_last_failure are equal" do
+      it "yields nothing" do
+        expect { |b|
+          BuildStatusReport.new(event, 1, 1, &b)
+        }.not_to yield_control
+      end
+    end
+
+    context "days_since_last_failure less than prev_days_since_last_failure" do
+      it "yields a happy message" do
+        expect { |b|
+          BuildStatusReport.new(event, 1, 0, &b)
+        }.to yield_with_args("tc is 1 day(s) without a failure!")
+      end
+    end
+
+    context "days_since_last_failure greater than prev_days_since_last_failure" do
+      it "yields a sad message" do
+        expect { |b|
+          BuildStatusReport.new(event, 0, 1, &b)
+        }.to yield_with_args("tc failed after 1 day(s)")
+      end
+    end
+  end
+end

--- a/spec/build_status_report_spec.rb
+++ b/spec/build_status_report_spec.rb
@@ -16,25 +16,12 @@ RSpec.describe BuildStatusReport do
     context "days_since_last_failure greater than prev_days_since_last_failure" do
       let(:days_since_last_failure) { 2 }
       let(:prev_days_since_last_failure) { 1 }
+      let(:most_successful_days) { 0 }
 
-      context "prev_days_since_last_failure greater than most_successful_days" do
-        let(:most_successful_days) { 0 }
-
-        it "yields a happy message" do
-          expect { |b|
-            BuildStatusReport.new(event, days_since_last_failure, prev_days_since_last_failure, most_successful_days, &b)
-          }.to yield_with_args("tc broke a new record! 2 days without a failure 🎉")
-        end
-      end
-
-      context "prev_days_since_last_failure less than most_successful_days" do
-        let(:most_successful_days) { 3 }
-
-        it "yields a happy message" do
-          expect { |b|
-            BuildStatusReport.new(event, days_since_last_failure, prev_days_since_last_failure, most_successful_days, &b)
-          }.to yield_with_args("tc is 2 days without a failure. The current record is 3. Aim for the top!")
-        end
+      it "yields a happy message" do
+        expect { |b|
+          BuildStatusReport.new(event, days_since_last_failure, prev_days_since_last_failure, most_successful_days, &b)
+        }.to yield_with_args("tc is 2 days without a failure")
       end
     end
 
@@ -58,7 +45,7 @@ RSpec.describe BuildStatusReport do
         it "yields a sad message" do
           expect { |b|
             BuildStatusReport.new(event, days_since_last_failure, prev_days_since_last_failure, most_successful_days, &b)
-          }.to yield_with_args("tc failed after 2 days. The current record is 3. Needs improvement!")
+          }.to yield_with_args("tc failed after 2 days, previous best was 3")
         end
       end
     end

--- a/spec/days_since_master_failure_repository_spec.rb
+++ b/spec/days_since_master_failure_repository_spec.rb
@@ -5,13 +5,17 @@ RSpec.describe DaysSinceMasterFailureRepository do
   let(:fake_redis) { instance_double(Redis) }
   let(:days_since_last_failure) { 2 }
   let(:last_reported_days) { 2 }
+  let(:most_successful_days) { 0 }
 
   before do
     allow(fake_redis).to receive(:setnx).with("last-failure-at-my-pipeline", instance_of(Integer))
+    allow(fake_redis).to receive(:setnx).with("most-successful-days-my-pipeline", instance_of(Integer))
     allow(fake_redis).to receive(:set).with("last-failure-at-my-pipeline", instance_of(Integer))
     allow(fake_redis).to receive(:set).with("last-reported-days-my-pipeline", instance_of(Integer))
+    allow(fake_redis).to receive(:set).with("most-successful-days-my-pipeline", instance_of(Integer))
     allow(fake_redis).to receive(:get).with("last-failure-at-my-pipeline").and_return(days_since_last_failure)
     allow(fake_redis).to receive(:get).with("last-reported-days-my-pipeline").and_return(last_reported_days)
+    allow(fake_redis).to receive(:get).with("most-successful-days-my-pipeline").and_return(most_successful_days)
   end
 
   describe ".new" do
@@ -19,6 +23,7 @@ RSpec.describe DaysSinceMasterFailureRepository do
       DaysSinceMasterFailureRepository.new(fake_redis, "my-pipeline")
 
       expect(fake_redis).to have_received(:setnx).with("last-failure-at-my-pipeline", instance_of(Integer)).ordered
+      expect(fake_redis).to have_received(:setnx).with("most-successful-days-my-pipeline", instance_of(Integer)).ordered
     end
   end
 
@@ -31,25 +36,61 @@ RSpec.describe DaysSinceMasterFailureRepository do
       }.to yield_with_args(instance_of(String))
     end
 
-    it "updates last-reported-days value" do
-      repository.record_result(instance_double(BuildkiteBuildFinishedEvent, passed?: false, pipeline: "my-pipeline")) {}
-
-      expect(fake_redis).to have_received(:set).with("last-reported-days-my-pipeline", instance_of(Integer))
-    end
-
     context "successful build" do
-      it "does not update last-failure-at value" do
+      before do
         repository.record_result(instance_double(BuildkiteBuildFinishedEvent, passed?: true, pipeline: "my-pipeline")) {}
+      end
 
+      it "does not update last-failure-at value" do
         expect(fake_redis).to_not have_received(:set).with("last-failure-at-my-pipeline", instance_of(Integer))
+      end
+
+      it "updates last-reported-days value" do
+        expect(fake_redis).to have_received(:set).with("last-reported-days-my-pipeline", instance_of(Integer))
+      end
+
+      context "not a new record" do
+        it "does not update most-successful-days value" do
+          expect(fake_redis).to_not have_received(:set).with("most-successful-days-pipeline", instance_of(Integer))
+        end
+      end
+
+      context "new record" do
+        let(:last_reported_days) { 12 }
+        let(:most_successful_days) { 9 }
+
+        it "does not update most-successful-days value" do
+          expect(fake_redis).to_not have_received(:set).with("most-successful-days-pipeline", instance_of(Integer))
+        end
       end
     end
 
     context "unsuccessful build" do
-      it "updates last-failure-at value" do
+      before do
         repository.record_result(instance_double(BuildkiteBuildFinishedEvent, passed?: false, pipeline: "my-pipeline")) {}
+      end
 
+      it "updates last-failure-at value" do
         expect(fake_redis).to have_received(:set).with("last-failure-at-my-pipeline", instance_of(Integer))
+      end
+
+      it "updates last-reported-days value" do
+        expect(fake_redis).to have_received(:set).with("last-reported-days-my-pipeline", instance_of(Integer))
+      end
+
+      context "not a new record" do
+        it "does not update most-successful-days value" do
+          expect(fake_redis).to_not have_received(:set).with("most-successful-days-pipeline", instance_of(Integer))
+        end
+      end
+
+      context "new record" do
+        let(:last_reported_days) { 12 }
+        let(:most_successful_days) { 9 }
+
+        it "updates most-successful-days value" do
+          expect(fake_redis).to have_received(:set).with("most-successful-days-my-pipeline", instance_of(Integer))
+        end
       end
     end
   end

--- a/spec/days_since_master_failure_spec.rb
+++ b/spec/days_since_master_failure_spec.rb
@@ -28,41 +28,27 @@ describe Lita::Handlers::DaysSinceMasterFailure, lita_handler: true do
         }
       }
 
-      context "days_since_last_failure and prev_days_since_last_failure are equal" do
+      context "record_result yields a message" do
         before do
-          allow(repository).to receive(:record_result).and_yield(0,0)
+          allow(repository).to receive(:record_result).and_yield("message")
+        end
+
+        it "sends a message" do
+          handler.timestamp_failure(payload)
+          expect(robot).to have_received(:send_message).with(
+            an_instance_of(Lita::Source), "message"
+          )
+        end
+      end
+
+      context "record_result does not yield a message" do
+        before do
+          allow(repository).to receive(:record_result)
         end
 
         it "does not send any messages" do
           handler.timestamp_failure(payload)
           expect(robot).to_not have_received(:send_message)
-        end
-      end
-
-      context "days_since_last_failure is greater than prev_days_since_last_failure" do
-        before do
-          allow(repository).to receive(:record_result).and_yield(1,0)
-        end
-
-        it "sends a message" do
-          handler.timestamp_failure(payload)
-          expect(robot).to have_received(:send_message).with(
-            an_instance_of(Lita::Source),
-            "Congratulations! 1 day(s) since the last master failure on tc"
-          )
-        end
-      end
-      context "days_since_last_failure is less than prev_days_since_last_failure" do
-        before do
-          allow(repository).to receive(:record_result).and_yield(0, 1)
-        end
-
-        it "sends a message" do
-          handler.timestamp_failure(payload)
-          expect(robot).to have_received(:send_message).with(
-            an_instance_of(Lita::Source),
-            "Oh Oh, 0 day(s) since the last master failure on tc"
-          )
         end
       end
     end


### PR DESCRIPTION
This adds a single additional message (originally I'd added 2, but it was a bit much) which reports what the previous best streak of successful builds was if we failed to match it.

It should act as a good reminder that we need to pay the build attention if we consistently fail to get close to previous reliability records.